### PR TITLE
Escape query string components

### DIFF
--- a/src/Client/Client.csproj
+++ b/src/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;net45;netstandard2.0;netstandard1.3</TargetFrameworks>
-    <Version>0.6.8</Version>
+    <Version>0.6.9</Version>
     <Title>Armut iterable.com Client</Title>
     <Authors>Armut Teknoloji A.Ş.</Authors>
     <Owners>Armut Teknoloji A.Ş.</Owners>

--- a/src/Client/InAppClient.cs
+++ b/src/Client/InAppClient.cs
@@ -1,4 +1,5 @@
-﻿using Armut.Iterable.Client.Contracts;
+﻿using System;
+using Armut.Iterable.Client.Contracts;
 using Armut.Iterable.Client.Core;
 using Armut.Iterable.Client.Core.Responses;
 using Armut.Iterable.Client.Models.BrowserModels;
@@ -21,9 +22,9 @@ namespace Armut.Iterable.Client
         public async Task<ApiResponse<GetMessagesResponse>> GetMessages(string email, string userId, int count, IterableMessagePlatform platform, string packageName)
         {
             var idSection = !string.IsNullOrEmpty(email)
-                ? $"email={email}"
-                : $"userId={userId}";
-            var packageNameUrlFragment = string.IsNullOrEmpty(packageName) ? "" : $"&packageName={packageName}";
+                ? $"email={Uri.EscapeDataString(email)}"
+                : $"userId={Uri.EscapeDataString(userId)}";
+            var packageNameUrlFragment = string.IsNullOrEmpty(packageName) ? "" : $"&packageName={Uri.EscapeDataString(packageName)}";
             return await _client.GetAsync<GetMessagesResponse>($"/api/inApp/getMessages?{idSection}&count={count}&platform={platform}&SDKVersion=None{packageNameUrlFragment}").ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Otherwise it won't work with an email address containing `+`, for example. `userId` and `packageName` are also escaped because theoretically they can be any string.